### PR TITLE
the parser was pushing empty lines as commands, causing errors thrown

### DIFF
--- a/src/simpleSqlParser.coffee
+++ b/src/simpleSqlParser.coffee
@@ -168,10 +168,11 @@ class SimpleSqlParser
 
     @sqlStream.on 'end', () =>
       @streamDone = true
-      @commandQueue.push
-        command: @residual.trimRight()
-        commandNumber: @commandNumber
-        lineNumber: @lineCommandStartedOn
+      if @residual.trimRight()
+        @commandQueue.push
+          command: @residual.trimRight()
+          commandNumber: @commandNumber
+          lineNumber: @lineCommandStartedOn
       if @waitingForStreamedCommand
         handleQueuedCommand()
         


### PR DESCRIPTION
Hey, I tried this out, but would always get a `ERROR: Error: The query is empty` thrown.  Looks like once it finishes parsing an sql file, it would push the remainder of the buffer on as a command, even if it was empty.  It would then barf on trying to execute an empty query.
